### PR TITLE
Fix Hugo's deprecation warning for .Site.BaseUrl

### DIFF
--- a/hugosite/layouts/_default/single.html
+++ b/hugosite/layouts/_default/single.html
@@ -12,7 +12,7 @@
         <div class="container">
             <!-- Content -->
             <article class="box post">
-                <div class="image featured" style="background-image: url('{{ .Site.BaseUrl }}{{ .Params.banner }}');"></div>
+                <div class="image featured" style="background-image: url('{{ .Site.BaseURL }}{{ .Params.banner }}');"></div>
                 <header>
                     <h2>{{ .Title }}</h2>
                     <p>{{ .Params.shortdesc }}</p>

--- a/hugosite/layouts/index.html
+++ b/hugosite/layouts/index.html
@@ -22,7 +22,7 @@
                             {{ range $.Site.Data.characters.characters }}
                                 <div class="4u">
                                     <section class="box">
-                                        <span class="image featured"><img src="{{ .Site.BaseUrl }}{{.image}}" alt="" /></span>
+                                        <span class="image featured"><img src="{{ .Site.BaseURL }}{{.image}}" alt="" /></span>
                                         <header>
                                             <h3>{{.name}}</h3>
                                         </header>
@@ -47,7 +47,7 @@
                             {{ range first 2 .Site.Pages }}
                                 <div class="6u">
                                     <section class="box">
-                                        <a href="{{ .Permalink }}" class="image featured"><img src="{{ .Site.BaseUrl }}{{ .Params.banner }}" alt="" /></a>
+                                        <a href="{{ .Permalink }}" class="image featured"><img src="{{ .Site.BaseURL }}{{ .Params.banner }}" alt="" /></a>
                                         <header>
                                             <h3>{{ .Title }}</h3>
                                             <p>Posted {{ .Date.Format "Jan 2,2006" }}</p>

--- a/hugosite/layouts/partials/footer.html
+++ b/hugosite/layouts/partials/footer.html
@@ -26,7 +26,7 @@
                     <header>
                         <h2>What's this all about?</h2>
                     </header>
-                    <a href="#" class="image featured"><img src="{{ .Site.BaseUrl }}{{ .Site.Params.banner }}" alt="" /></a>
+                    <a href="#" class="image featured"><img src="{{ .Site.BaseURL }}{{ .Site.Params.banner }}" alt="" /></a>
                     <p>{{ .Site.Params.description }}</p>
                 </section>
             </div>

--- a/hugosite/layouts/partials/head.html
+++ b/hugosite/layouts/partials/head.html
@@ -2,16 +2,16 @@
     <title>{{ .Site.Title }}</title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="description" content="{{ if .IsNode }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ else }}{{ with .Description }}{{ . }}{{ end }}{{ end }}" />
-    
+
     <meta name="keywords" content="adventure time,cartoon network,cartoons,finn,jake,princess bubblegum" />
     <!--[if lte IE 8]><script src="css/ie/html5shiv.js"></script><![endif]-->
-    <script src="{{ .Site.BaseUrl }}/assets/js/jquery.min.js"></script>
-    <script src="{{ .Site.BaseUrl }}/assets/js/skel.min.js"></script>
-    <script src="{{ .Site.BaseUrl }}/assets/js/skel-layers.min.js"></script>
-    <script src="{{ .Site.BaseUrl }}/assets/js/init.js"></script>
-    <link rel="stylesheet" href="{{ .Site.BaseUrl }}/assets/css/skel.css" />
-    <link rel="stylesheet" href="{{ .Site.BaseUrl }}/assets/css/style.css" />
-    <link rel="stylesheet" href="{{ .Site.BaseUrl }}/assets/css/style-desktop.css" />
-    <!--[if lte IE 8]><link rel="stylesheet" href="{{ .Site.BaseUrl }}/assets/css/ie/v8.css" /><![endif]-->
+    <script src="{{ .Site.BaseURL }}/assets/js/jquery.min.js"></script>
+    <script src="{{ .Site.BaseURL }}/assets/js/skel.min.js"></script>
+    <script src="{{ .Site.BaseURL }}/assets/js/skel-layers.min.js"></script>
+    <script src="{{ .Site.BaseURL }}/assets/js/init.js"></script>
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}/assets/css/skel.css" />
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}/assets/css/style.css" />
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}/assets/css/style-desktop.css" />
+    <!--[if lte IE 8]><link rel="stylesheet" href="{{ .Site.BaseURL }}/assets/css/ie/v8.css" /><![endif]-->
     <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .RSSlink }}" />
 </head>


### PR DESCRIPTION
Running `hugo` currently produces the following deprecation warning:

> ERROR: Site's .BaseUrl is deprecated and will be removed in Hugo 0.15. Use .BaseURL instead.
