### PR TITLE
Fix missing index page banner for Jekyll

### DIFF
--- a/jekyllsite/_includes/header.html
+++ b/jekyllsite/_includes/header.html
@@ -5,7 +5,7 @@
         <!-- Logo -->
             <h1><a href="/">{{ site.title }}</a></h1>
         
-        {% if page.url == "/index.html" %}
+        {% if page.url == "/" %}
         <!-- Banner -->
             <section id="banner">
                 <header>


### PR DESCRIPTION
Jekyll fails to include the banner for the index page because the index page URL seems to be `/` rather than `index.html`.
